### PR TITLE
RMX2061: Initial official OTA rollout

### DIFF
--- a/GAPPS/RMX2061.json
+++ b/GAPPS/RMX2061.json
@@ -1,0 +1,22 @@
+{
+        "response": [
+                {
+                        "maintainer": "Shahid Shamim",
+                        "oem": "Realme",
+                        "device": "6 Pro",
+                        "filename": "MistOS-4.2-Fizzle-16.0-GAPPS-20251021-RMX2061-OFFICIAL.zip",
+                        "download": "https://sourceforge.net/projects/project-mistos/files/Android16/RMX2061/MistOS-4.2-Fizzle-16.0-GAPPS-20251021-RMX2061-OFFICIAL.zip/download",
+                        "timestamp": 1761046140,
+                        "md5": "78216d2ab192809590616201ba1c200c",
+                        "sha256": "1f57ed01a4a8b8e5534bdc107877b7365e736c67a4fc7d4f1d51ca42319c9a73",
+                        "size": 3064747897,
+                        "version": "4.2-Fizzle",
+                        "buildtype": "stable",
+                        "forum": "",
+                        "recovery": "https://sourceforge.net/projects/rmx2061/files/Recovery/",
+                        "paypal": "https://paypal.me/shaenix",
+                        "telegram": "https://t.me/thenoah77"
+                }
+        ]
+}
+

--- a/changelogs/RMX2061.txt
+++ b/changelogs/RMX2061.txt
@@ -1,0 +1,10 @@
+Device-specific changelog:
+Build type: Official
+Device: Realme 6 Pro (RMX2061)
+Device maintainer: Shahid Shamim
+
+=====================
+21-10-2025
+=====================
+Device:
+- Initial Official build for RMX2061


### PR DESCRIPTION
* Added RMX2061.json to the official devices repo for Mist OS
* Included changelogs for the initial build