### PR TITLE
Devices: Add giulia (OnePlus 13R) and giuliac (OnePlus Ace 5)

### DIFF
--- a/buildDevices.json
+++ b/buildDevices.json
@@ -263,6 +263,36 @@
       "picobuild": false,
       "minibuild": true,
       "vanillaBuild": true
-    }
+      },
+      {
+      "OEM": "OnePlus",
+      "deviceName": "OnePlus 13R",
+      "codename": "giulia",
+      "maintainer": "ShivaOPP",
+      "telegram": "https://t.me/itzshivaopp",
+      "donate": "",
+      "enabled": true,
+      "repo": "MistOS-Devices/device_oneplus_giulia",
+      "build_type": "user",
+      "gappsbuild": true,
+      "picobuild": false,
+      "minibuild": true,
+      "vanillaBuild": true
+      },
+      {
+      "OEM": "OnePlus",
+      "deviceName": "OnePlus Ace 5",
+      "codename": "giuliac",
+      "maintainer": "ShivaOPP",
+      "telegram": "https://t.me/itzshivaopp",
+      "donate": "",
+      "enabled": true,
+      "repo": "MistOS-Devices/device_oneplus_giuliac",
+      "build_type": "user",
+      "gappsbuild": true,
+      "picobuild": false,
+      "minibuild": false,
+      "vanillaBuild": false
+      },
   ]
 }


### PR DESCRIPTION
Add OnePlus 13R (giulia) and OnePlus Ace 5 (giuliac) for Auto-Trigger.

Maintainer: ShivaOPP (@itzshivaopp)
Device trees: MistOS-Devices/device_oneplus_giulia
              MistOS-Devices/device_oneplus_giuliac
Common tree:  MistOS-Devices/device_oneplus_sm8650-common